### PR TITLE
Constructor yields self for configuration (e.g. namespace)

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -15,6 +15,7 @@ class Statsd
   # @param [Integer] port your statsd port
   def initialize(host, port=8125)
     @host, @port = host, port
+    yield self if block_given?
   end
 
   # @param [String] stat stat name

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -21,6 +21,13 @@ describe Statsd do
     it "should default the port to 8125" do
       Statsd.new('localhost').instance_variable_get('@port').must_equal 8125
     end
+
+    it "should yield itself for further configuration, e.g. namespace" do
+      statsd = Statsd.new('localhost') do |s|
+        s.namespace = "a.b"
+      end
+      statsd.namespace.must_equal "a.b"
+    end
   end
 
   describe "#increment" do


### PR DESCRIPTION
Provides the ability to assign a namespace without using a temporary variable, and without adding messy optional params to the constructor.

Example usage:

``` ruby
def stats
  Statsd.new("localhost") do |s|
    s.namespace = "my.namespace"
  end
end

stats.increment "counter"
```

Possibly also useful for easy scoped usage:

``` ruby
Statsd.new("localhost") do |s|
  s.increment "one"
  s.increment "two"
end
```
