### PR TITLE
Replace :: with . as a delimiter, also replace reserved chars [:|@] with 

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -9,6 +9,8 @@ require 'socket'
 #     statsd.increment 'garets'
 #     statsd.timing 'glork', 320
 class Statsd
+
+  RESERVED_CHARS_REGEX = /[\:\|\@]/
   attr_accessor :namespace
   
   # @param [String] host your statsd host
@@ -50,6 +52,7 @@ class Statsd
 
   def send(stat, delta, type, sample_rate)
     prefix = "#{@namespace}." unless @namespace.nil?
+    stat = stat.gsub('::', '.').gsub(RESERVED_CHARS_REGEX, '_')
     sampled(sample_rate) { socket.send("#{prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}", 0, @host, @port) }
   end
 


### PR DESCRIPTION
Replace :: with . as a delimiter, also replace reserved chars [:|@] with _

This allows for ruby class names to be used as stat names.
Also cleaning up stat names to remove statsd reserved characters
