### PR TITLE
Allow disabling statsd

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -16,6 +16,9 @@ class Statsd
   # A namespace to prepend to all statsd calls.
   attr_accessor :namespace
 
+  # Toggle for enabling/disabling statsd
+  attr_accessor :enabled
+
   #characters that will be replaced with _ in stat names
   RESERVED_CHARS_REGEX = /[\:\|\@]/
   
@@ -28,6 +31,7 @@ class Statsd
   # @param [String] host your statsd host
   # @param [Integer] port your statsd port
   def initialize(host, port=8125)
+    @enabled = true
     @host, @port = host, port
   end
 
@@ -91,7 +95,7 @@ class Statsd
 
   def send_to_socket(message)
     self.class.logger.debug {"Statsd: #{message}"} if self.class.logger
-    socket.send(message, 0, @host, @port)
+    socket.send(message, 0, @host, @port) if enabled
   end
 
   def socket; @socket ||= UDPSocket.new end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -23,6 +23,17 @@ describe Statsd do
     end
   end
 
+  describe "#enabled" do
+    it "should default to true" do
+      @statsd.enabled.must_equal true
+    end
+
+    it "can be disabled" do
+      @statsd.enabled = false
+      @statsd.enabled.must_equal false
+    end
+  end
+
   describe "#increment" do
     it "should format the message according to the statsd spec" do
       @statsd.increment('foobar')
@@ -34,6 +45,15 @@ describe Statsd do
       it "should format the message according to the statsd spec" do
         @statsd.increment('foobar', 0.5)
         @statsd.socket.recv.must_equal ['foobar:1|c|@0.5']
+      end
+    end
+
+    describe "when disabled" do
+      before { @statsd.enabled = false }
+
+      it "should send nothing" do
+        @statsd.increment('foobar')
+        @statsd.socket.recv.must_equal nil
       end
     end
   end


### PR DESCRIPTION
This is useful for dev environments.

E.g.:
  @statsd = Statsd.new('127.0.0.1')
  @statsd.enabled = false
  @statsd.increment('foo') # does nothing
