### PR TITLE
Add method to send gauge values

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -66,8 +66,7 @@ class Statsd
   #
   # @param [String] stat stat name
   # @param [Integer] value value
-  # @param [Integer] sample_rate sample rate, 1 for always
-  def gauge(stat, value, sample_rate=1); send stat, value, 'g', sample_rate end
+  def gauge(stat, value); send stat, value, 'g' end
 
   # Reports execution time of the provided block using {#timing}.
   #
@@ -93,7 +92,7 @@ class Statsd
   def send(stat, delta, type, sample_rate)
     prefix = "#{@namespace}." unless @namespace.nil?
     stat = stat.to_s.gsub('::', '.').gsub(RESERVED_CHARS_REGEX, '_')
-    sampled(sample_rate) { send_to_socket("#{prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}") }
+    sampled(sample_rate) { send_to_socket("#{prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate && sample_rate < 1}") }
   end
 
   def send_to_socket(message)

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -94,14 +94,6 @@ describe Statsd do
       @statsd.gauge('gaugor', 50)
       @statsd.socket.recv.must_equal ['gaugor:50|g']
     end
-
-    describe "with a sample rate" do
-      before { class << @statsd; def rand; 0; end; end } # ensure delivery
-      it "should format the message according to the statsd spec" do
-        @statsd.gauge('gaugor', 50, 0.5)
-        @statsd.socket.recv.must_equal ['gaugor:50|g|@0.5']
-      end
-    end
   end
 
   describe "#sampled" do


### PR DESCRIPTION
Gauges are formatted like `gaugor:333|g` and used to track arbitrary values
