### PR TITLE
Change rcov to simplecov for compatibility with ruby 1.9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ Jeweler::Tasks.new do |gem|
   gem.add_development_dependency "minitest", ">= 0"
   gem.add_development_dependency "yard", "~> 0.6.0"
   gem.add_development_dependency "jeweler", "~> 1.5.2"
-  gem.add_development_dependency "rcov", ">= 0"
+  gem.add_development_dependency "simplecov", ">= 0"
 end
 Jeweler::RubygemsDotOrgTasks.new
 
@@ -23,14 +23,6 @@ Rake::TestTask.new(:spec) do |spec|
   spec.libs << 'lib' << 'spec'
   spec.pattern = 'spec/**/*_spec.rb'
   spec.verbose = true
-end
-
-require 'rcov/rcovtask'
-Rcov::RcovTask.new do |spec|
-  spec.libs << 'lib' << 'spec'
-  spec.pattern = 'spec/**/*_spec.rb'
-  spec.verbose = true
-  spec.rcov_opts << "--exclude spec,gems"
 end
 
 task :default => :spec

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -3,6 +3,10 @@ require 'minitest/autorun'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+
+require 'simplecov'
+SimpleCov.start
+
 require 'statsd'
 require 'logger'
 

--- a/statsd-ruby.gemspec
+++ b/statsd-ruby.gemspec
@@ -40,18 +40,18 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<minitest>, [">= 0"])
       s.add_development_dependency(%q<yard>, ["~> 0.6.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
-      s.add_development_dependency(%q<rcov>, [">= 0"])
+      s.add_development_dependency(%q<simplecov>, [">= 0"])
     else
       s.add_dependency(%q<minitest>, [">= 0"])
       s.add_dependency(%q<yard>, ["~> 0.6.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
-      s.add_dependency(%q<rcov>, [">= 0"])
+      s.add_dependency(%q<simplecov>, [">= 0"])
     end
   else
     s.add_dependency(%q<minitest>, [">= 0"])
     s.add_dependency(%q<yard>, ["~> 0.6.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
-    s.add_dependency(%q<rcov>, [">= 0"])
+    s.add_dependency(%q<simplecov>, [">= 0"])
   end
 end
 


### PR DESCRIPTION
rcov doesn't work in 1.9, but simplecov does. This fixes the build process to work in 1.9
