### PR TITLE
Added Statsd::Mock for usage outside production.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,6 +24,20 @@ Bundler:
   statsd = Statsd.new('localhost').tap{|sd| sd.namespace = 'account'}
   statsd.increment 'activate'
 
+= Usage outside production
+
+Usually it's undesirable to send stats while not in production. For this use-case the class Statd::Mock is provided. It behaves exactly like the Statsd class, but never sends the stats.
+
+  # given 'production?' tests whether this is an production environment.
+  if production?
+    $statsd = Statsd.new 'localhost', 8125
+  else
+    require 'statsd/mock'
+    $statsd = Statsd::Mock.new
+  end
+
+Just like Statsd, Statsd::Mock logs to the Statsd logger so you can see what would have been send.
+
 = Testing
 
 Run the specs with <tt>rake spec</tt>

--- a/lib/statsd/mock.rb
+++ b/lib/statsd/mock.rb
@@ -1,0 +1,33 @@
+require 'statsd'
+
+# A class which behaves exactly like {Statsd} but doens't send
+# the stats to the server. It however does normal logging, so one
+# can see what would be sent to sent to statsd.
+#
+# This class is usefull for development and testing environments.
+#
+# @example set $statsd depending on the RACK_ENV
+#  if ENV['RACK_ENV'] == 'production'
+#    $statsd = Statsd.new
+#  else
+#    require 'statsd/mock'
+#    $statsd = Statsd::Mock.new
+#  end
+#  # $statsd is ready to receive stats but will only send them in production.
+#
+class Statsd::Mock < Statsd
+
+private
+
+  class UDPSocketMock
+
+    def send(*_)
+    end
+
+  end
+
+  def socket
+    @socket ||= UDPSocketMock.new
+  end
+
+end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,0 +1,61 @@
+# This is a set of shared test which check whether an object 
+# responds to all stats sending methods.
+A_STATSD_DUCKTYPE = proc do
+
+  let(:instance){ described_class.new }
+
+  it "should respond to :increment" do
+    assert_respond_to(instance,:increment)
+  end
+
+  it "should respond to :decrement" do
+    assert_respond_to(instance,:decrement)
+  end
+
+  it "should respond to :count" do
+    assert_respond_to(instance,:count)
+  end
+
+  it "should respond to :gauge" do
+    assert_respond_to(instance,:gauge)
+  end
+
+  it "should respond to :timing" do
+    assert_respond_to(instance,:timing)
+  end
+
+  it "should respond to :time" do
+    assert_respond_to(instance,:time)
+  end
+
+end
+
+# This set of test check whether an object logs to the 
+# global statsd logger.
+LOG_TO_STATSD_LOGGER = proc do
+
+  require 'stringio'
+
+  let(:instance){ described_class.new }
+
+  let(:buffer){ StringIO.new }
+
+  before { Statsd.logger = Logger.new(buffer)}
+
+  it "should write to the log in debug" do
+    Statsd.logger.level = Logger::DEBUG
+
+    instance.increment('foobar')
+
+    buffer.string.must_match "Statsd: foobar:1|c"
+  end
+
+  it "should not write to the log unless debug" do
+    Statsd.logger.level = Logger::INFO
+
+    instance.increment('foobar')
+
+    buffer.string.must_be_empty
+  end
+
+end

--- a/spec/statsd_mock_spec.rb
+++ b/spec/statsd_mock_spec.rb
@@ -1,0 +1,23 @@
+require 'helper'
+require 'statsd/mock'
+require 'shared_examples'
+
+describe Statsd::Mock do
+
+  describe "should behave like a Statsd ducktype" do
+
+    let(:described_class){ Statsd::Mock }
+
+    instance_eval( &A_STATSD_DUCKTYPE )
+
+  end
+
+  describe "should log to global logger" do
+
+    let(:described_class){ Statsd }
+
+    instance_eval( &LOG_TO_STATSD_LOGGER )
+
+  end
+
+end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'shared_examples'
 
 describe Statsd do
   class Statsd
@@ -11,6 +12,14 @@ describe Statsd do
   end
 
   after { Thread.current[:statsd_socket] = nil }
+
+  describe "should behave like a Statsd ducktype" do
+
+    let(:described_class){ Statsd }
+
+    instance_eval( &A_STATSD_DUCKTYPE )
+
+  end
 
   describe "#initialize" do
     it "should set the host and port" do
@@ -189,25 +198,12 @@ describe Statsd do
     end
   end
 
-  describe "with logging" do
-    require 'stringio'
-    before { Statsd.logger = Logger.new(@log = StringIO.new)}
+  describe "should log to global logger" do
 
-    it "should write to the log in debug" do
-      Statsd.logger.level = Logger::DEBUG
+    let(:described_class){ Statsd }
 
-      @statsd.increment('foobar')
+    instance_eval( &LOG_TO_STATSD_LOGGER )
 
-      @log.string.must_match "Statsd: foobar:1|c"
-    end
-
-    it "should not write to the log unless debug" do
-      Statsd.logger.level = Logger::INFO
-
-      @statsd.increment('foobar')
-
-      @log.string.must_be_empty
-    end
   end
 
   describe "stat names" do


### PR DESCRIPTION
Hi

I added class which mocks Statsd, so one can have a silent Statsd object in development/test/.. mode.  I'm currently using this on one of my applications and think it's really useful.

Cheers'
Hannes
