### PR TITLE
Add support for the "set" stat type.

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -181,6 +181,22 @@ class Statsd
     send_stats stat, value, :g, sample_rate
   end
 
+  # Sends an arbitary set value for the given stat to the statsd server.
+  #
+  # This is for recording counts of unique events, which are useful to
+  # see on graphs to correlate to other values.  For example, a deployment
+  # might get recorded as a set, and be drawn as annotations on a CPU history
+  # graph.
+  #
+  # @param [String] stat stat name.
+  # @param [Numeric] value event value.
+  # @param [Numeric] sample_rate sample rate, 1 for always
+  # @example Report a deployment happening:
+  #   $statsd.set('deployment', DEPLOYMENT_EVENT_CODE)
+  def set(stat, value, sample_rate=1)
+    send_stats stat, value, :s, sample_rate
+  end
+
   # Sends a timing (in ms) for the given stat to the statsd server. The
   # sample_rate determines what percentage of the time this report is sent. The
   # statsd server then uses the sample_rate to correctly track the average

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -111,6 +111,21 @@ describe Statsd do
     end
   end
 
+  describe "#set" do
+    it "should format the message according to the statsd spec" do
+      @statsd.set('foobar', 765)
+      @socket.recv.must_equal ['foobar:765|s']
+    end
+
+    describe "with a sample rate" do
+      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      it "should format the message according to the statsd spec" do
+        @statsd.set('foobar', 500, 0.5)
+        @socket.recv.must_equal ['foobar:500|s|@0.5']
+      end
+    end
+  end
+
   describe "#time" do
     it "should format the message according to the statsd spec" do
       @statsd.time('foobar') { 'test' }


### PR DESCRIPTION
From the [etsy/statsd](http://github.com/etsy/statsd)/README.md, 

```
StatsD supports counting unique occurences of events between 
flushes, using a Set to store all occuring events.
```

This change adds support for sending metrics of the `set` type to a statsd server.

**Note**: I'm not convinced I've fully understand the intent of the event-type (see the rdoc I wrote), but I'm pretty sure the code is doing the correct thing.
