### PR TITLE
Fix bug in #postfix= with a blank value

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -123,8 +123,14 @@ class Statsd
     @prefix = "#{namespace}."
   end
 
+  # @attribute [w] postfix
+  #   A value to be appended to the stat name after a '.'. If the value is
+  #   blank then the postfix will be reset to nil (rather than to '.').
   def postfix=(pf)
-    @postfix = ".#{pf}"
+    case pf
+    when nil, false, '' then @postfix = nil
+    else @postfix = ".#{pf}"
+    end
   end
 
   # @attribute [w] host

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -228,6 +228,18 @@ describe Statsd do
     end
   end
 
+  describe '#postfix=' do
+    describe "when nil, false, or empty" do
+      it "should set postfix to nil" do
+        [nil, false, ''].each do |value|
+          @statsd.postfix = 'a postfix'
+          @statsd.postfix = value
+          @statsd.postfix.must_equal nil
+        end
+      end
+    end
+  end
+
   describe "with logging" do
     require 'stringio'
     before { Statsd.logger = Logger.new(@log = StringIO.new)}


### PR DESCRIPTION
@postfix was being set to `'.'` for `nil` or `''` or `'.false'` for
`false`. This ensures that the value will be correctly reset to `nil`
for `nil`, `false`, or `''` values.
