### PR TITLE
Allow setting the host and port on a Statsd::Batch object

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -43,7 +43,11 @@ class Statsd
 
     extend Forwardable
     def_delegators :@statsd,
-      :namespace, :namespace=, :host, :port, :prefix, :postfix
+      :namespace, :namespace=,
+      :host, :host=,
+      :port, :port=,
+      :prefix,
+      :postfix
 
     attr_accessor :batch_size
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -321,6 +321,24 @@ describe Statsd do
       @socket.recv.must_equal %w[foobar:1|c]
     end
 
+    it "should support setting namespace for the underlying instance" do
+      batch = Statsd::Batch.new(@statsd)
+      batch.namespace = 'ns'
+      @statsd.namespace.must_equal 'ns'
+    end
+
+    it "should support setting host for the underlying instance" do
+      batch = Statsd::Batch.new(@statsd)
+      batch.host = '1.2.3.4'
+      @statsd.host.must_equal '1.2.3.4'
+    end
+
+    it "should support setting port for the underlying instance" do
+      batch = Statsd::Batch.new(@statsd)
+      batch.port = 42
+      @statsd.port.must_equal 42
+    end
+
   end
 
   describe "thread safety" do


### PR DESCRIPTION
I have some code that configured Statsd programmatically. In order to use `Statsd::Batch` as a drop-in replacement (config-wise) it needs to support the host and port setters so I added them in the attached pull request.
