### PR TITLE
Add Statsd::RackEndpoint

### DIFF
--- a/lib/statsd/rack_endpoint.rb
+++ b/lib/statsd/rack_endpoint.rb
@@ -1,0 +1,89 @@
+require 'statsd'
+require 'rack'
+
+# = RackEndpoint
+#
+# A Rack endpoint that accepts HTTP requests and forwards
+# them on to a Statsd client.
+#
+# @example Set up an endpoint to collect stats at /api/stats/
+#   run Statsd::RackEndpoint, $statsd, '/api/stats/'
+# @example Send some stats from a jQuery-enabled page
+#   $.ajax('/api/stats/increment/learn_more.next.clicked')
+#
+# This endpoint handles requests that look like
+#
+#  * `/:path_prefix/increment/:stat`
+#  * `/:path_prefix/decrement/:stat`
+#  * `/:path_prefix/count/:stat/:n`
+#  * `/:path_prefix/gauge/:stat/:n`
+#  * `/:path_prefix/set/:stat/:n`
+#  * `/:path_prefix/timing/:stat/:n`
+#
+# It also supports a `sample_rate` query parameter.
+class Statsd::RackEndpoint
+
+  class NonNumericArgumentError < ArgumentError
+    attr_reader :value
+    def initialize(value, parent)
+      @value = value
+      super(parent)
+    end
+  end
+
+  attr_reader :client
+
+  # @param [Statsd] client the object that will make the back-end UDP requests
+  #   to your statsd server.
+  # @param [String] path_prefix where this endpoint is mounted. This *must*
+  #   match where you actually mount the endpoint in your `config.ru`.
+  def initialize(client, path_prefix = '/statsd/')
+    @client = client
+    @path_regex = %r{#{path_prefix}(.+)}
+  end
+
+  def call(env)
+    request = Rack::Request.new(env)
+    return build_response(404, 'Only POSTs are allowed') unless request.post?
+
+    args = statsd_args(request)
+    return build_response(404, 'Not a statsd request') unless args
+
+    client.send *args
+    build_response 204
+  rescue NonNumericArgumentError => e
+    build_response 422, "#{e.value} is not a number"
+  end
+
+  private
+
+  def statsd_args(request)
+    match = @path_regex.match(request.path)
+    return nil unless match
+    action, stat, value = match[1].split('/')
+
+    result = case action
+    when 'increment', 'decrement'
+      [ action, stat ]
+    when 'count', 'gauge', 'set', 'timing'
+      [ action, stat, numeric(value) ]
+    else
+      nil
+    end
+
+    sample_rate = request['sample_rate']
+    result.push numeric(sample_rate) if result && sample_rate
+    result
+  end
+
+  def build_response(status, message = [])
+    Rack::Response.new(message, status, { 'Content-Type' => 'text/plain' }).finish
+  end
+
+  def numeric(string)
+    string =~ /\./ ? Float(string) : Integer(string)
+  rescue ArgumentError => e
+    raise NonNumericArgumentError.new(string, e)
+  end
+
+end

--- a/spec/rack_endpoint_spec.rb
+++ b/spec/rack_endpoint_spec.rb
@@ -1,0 +1,100 @@
+require 'helper'
+require 'rack/test'
+require 'statsd/rack_endpoint'
+
+describe Statsd::RackEndpoint do
+
+  include Rack::Test::Methods
+  attr_reader :app
+
+  class FakeStatsClient
+    attr_reader :last_received
+
+    %w{ increment decrement count gauge set timing }.each do |m|
+      define_method m do |*args|
+        @last_received = [ m.to_sym, *args ]
+      end
+    end
+  end
+
+  before do
+    @client = FakeStatsClient.new
+    @app = Statsd::RackEndpoint.new(@client)
+  end
+
+  it 'accepts a statsd client' do
+    @app.client.must_equal @client
+  end
+
+  it 'responds with Not Found for a POST to /somewhere/else' do
+    post '/somewhere/else'
+    last_response.must_be :not_found?
+  end
+
+  it 'responds with Not Found for a GET to /statsd/increment/chickens.rubber' do
+    get '/statsd/increment/naps-taken'
+    last_response.must_be :not_found?
+  end
+
+  it 'responds with Not Found for a POST to /statsd/reticulate/splines' do
+    post '/statsd/reticulate/splines'
+    last_response.must_be :not_found?
+  end
+
+  it 'responds with No Content for valid statsd requests' do
+    post '/statsd/increment/kittens-mailed-to-abu-dhabi'
+    last_response.status.must_equal 204
+  end
+
+  it 'forwards increments to the statsd client' do
+    post '/statsd/increment/chickens.rubber'
+    @client.last_received.must_equal [ :increment, 'chickens.rubber' ]
+  end
+
+  it 'forwards decrements to the statsd client' do
+    post '/statsd/decrement/eaten.lasagnas'
+    @client.last_received.must_equal [ :decrement, 'eaten.lasagnas' ]
+  end
+
+  it "forwards counts to the client" do
+    post '/statsd/count/eaten.ferns/3'
+    @client.last_received.must_equal [ :count, 'eaten.ferns', 3 ]
+  end
+
+  it 'responds to a request with a non-numeric count with a client error' do
+    post '/statsd/count/eaten.pizzas/three'
+    last_response.status.must_equal 422
+  end
+
+  it "forwards gagues to the client" do
+    post '/statsd/gauge/weight/19582'
+    @client.last_received.must_equal [ :gauge, 'weight', 19582 ]
+  end
+
+  it "forwards sets to the client" do
+    post '/statsd/set/episode-number/411'
+    @client.last_received.must_equal [ :set, 'episode-number', 411 ]
+  end
+
+  it "forwards timings to the client" do
+    post '/statsd/timing/duration.dinner/2027'
+    @client.last_received.must_equal [ :timing, 'duration.dinner', 2027 ]
+  end
+
+  it "supports a sample_rate parameter" do
+    post '/statsd/timing/duration.nap/5922984?sample_rate=0.2'
+    @client.last_received.last.must_equal 0.2
+  end
+
+  it "responds to a request with a non-numeric sample_rate with a client error" do
+    post '/statsd/count/drunk.coffee.ounces/32?sample_rate=two-tenths'
+    last_response.status.must_equal 422
+  end
+
+  it 'supports configuring the URL prefix' do
+    @app = Statsd::RackEndpoint.new(@client, '/api/stats/')
+    post '/api/stats/timing/duration.exercise/0'
+    last_response.status.must_equal 204
+  end
+
+end

--- a/statsd-ruby.gemspec
+++ b/statsd-ruby.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new("statsd-ruby", "1.2.0") do |s|
   s.add_development_dependency "yard"
   s.add_development_dependency "simplecov", ">= 0.6.4"
   s.add_development_dependency "rake"
+  s.add_development_dependency "rack-test"
 end
 


### PR DESCRIPTION
This endpoint makes it easy for sites to collect client-side stats. It exposes (most of) the functionality of the existing `Statsd` client object as a Rack endpoint.

It is _not_ automatically required when loading the library, nor did I add Rack as a runtime dependency. (I would have added it as an optional dependency if Rubygems supported that concept.)
