### PR TITLE
New statsd interceptor for wrapping instances

### DIFF
--- a/lib/statsd/interceptor.rb
+++ b/lib/statsd/interceptor.rb
@@ -1,0 +1,24 @@
+require 'statsd'
+
+class Statsd
+
+  class Interceptor
+    attr_reader :target, :statsd
+
+    def initialize(target, statsd)
+      @target, @statsd = target, statsd
+    end
+
+    def method_missing(method, *args, &block)
+      stat = "#{target.class}.#{method}"
+      statsd.time(stat) do
+        target.send(method, *args, &block)
+      end
+    rescue => e
+      statsd.increment("#{stat}.errors", 1)
+      raise e
+    end
+
+  end
+
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -5,6 +5,7 @@ require 'simplecov'
 SimpleCov.start
 
 require 'statsd'
+require 'statsd/interceptor'
 require 'logger'
 
 class FakeUDPSocket


### PR DESCRIPTION
This is a pattern I've used in one of the apps I have and figured it
might be a useful contribution.

To use it simply wrap any object and call methods on it as normal.

For instance, if you wanted to time every call to a redis client:

```
require 'statsd/interceptor'
require 'redis'

statsd = Statsd.new('localhost', 1234)
redis = Statsd::Interceptor.new(Redis.current, statsd)

redis.set "blah", true
redis.get "blah"
```

Would produce timings such as:
"Redis.get:1|ms" and
"Redis.set:1|ms"

If the target raises any errors an "errors" counter is incremented:
"Redis.get.errors:1|c"
"Redis.set.errors:1|c"
