### PR TITLE
Add statsd-ruby.rb to auto require statsd

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,7 +5,7 @@ A Ruby client for {StatsD}[https://github.com/etsy/statsd]
 = Installing
 
 Bundler:
-  gem "statsd-ruby", :require => "statsd"
+  gem "statsd-ruby"
 
 = Basic Usage
 

--- a/lib/statsd-ruby.rb
+++ b/lib/statsd-ruby.rb
@@ -1,0 +1,1 @@
+require 'statsd'


### PR DESCRIPTION
By adding lib/statsd-ruby.rb (which just requires statsd.rb), the
'require' option can be omitted when using statsd in a Gemfile.
