### PR TITLE
Resolve hostname once

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -1,5 +1,6 @@
 require 'socket'
 require 'forwardable'
+require 'resolv'
 
 # = Statsd: A Statsd client (https://github.com/etsy/statsd)
 #
@@ -140,7 +141,7 @@ class Statsd
   # @attribute [w] host
   #   Writes are not thread safe.
   def host=(host)
-    @host = host || '127.0.0.1'
+    @host = Resolv.getaddress(host || '127.0.0.1')
   end
 
   # @attribute [w] port

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -14,7 +14,7 @@ describe Statsd do
 
   describe "#initialize" do
     it "should set the host and port" do
-      @statsd.host.must_equal 'localhost'
+      @statsd.host.must_equal '127.0.0.1'
       @statsd.port.must_equal 1234
     end
 
@@ -33,9 +33,14 @@ describe Statsd do
       @statsd.port.must_equal 5678
     end
 
-    it "should not resolve hostnames to IPs" do
+    it "should resolve hostnames to IPs" do
       @statsd.host = 'localhost'
-      @statsd.host.must_equal 'localhost'
+      @statsd.host.must_equal '127.0.0.1'
+    end
+    
+    it "should resolve IPs to IPs" do
+      @statsd.host = '127.0.0.1'
+      @statsd.host.must_equal '127.0.0.1'
     end
 
     it "should set nil host to default" do


### PR DESCRIPTION
Hey, 

I'm not entirely sure why you do not resolve the hostname once in your version, given we just had a production issue related to this decision I figured it a reasonable idea to supply a patch that caches the resolved address. Is the concerns that the IP address of the host may change?

Making this change has a slight performance increase (a few ms per request according to http://matt.aimonetti.net/posts/2013/06/26/practical-guide-to-graphite-monitoring/ ) - it also stops busy sites like ours crippling our DNS server when under load. We could, as you suggest, run a caching dns server on each of our app servers - but that seems like a poor tradeoff when the library could do it so easily.

As an aside, this brings it inline with the python statsd client too: https://github.com/jsocol/pystatsd/blob/master/statsd/client.py#L42