### PR TITLE
Add an optional way to reuse a socket instead of finding it in-Thread

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -27,6 +27,9 @@ Bundler:
   statsd = Statsd.new('localhost').tap{|sd| sd.namespace = 'account'}
   statsd.increment 'activate'
 
+  # Create a Statsd client that uses a single socket
+  statsd = Statsd.new 'localhost', 9125, UDPSocket.new
+
 = Testing
 
 Run the specs with <tt>rake spec</tt>

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -234,11 +234,13 @@ class Statsd
 
   # @param [String] host your statsd host
   # @param [Integer] port your statsd port
-  def initialize(host = '127.0.0.1', port = 8125)
+  # @param [Object] A socket object (probably UDPSocket) to reuse
+  def initialize(host = '127.0.0.1', port = 8125, socket = nil)
     self.host, self.port = host, port
     @prefix = nil
     @batch_size = 10
     @postfix = nil
+    @socket = socket
   end
 
   # @attribute [w] namespace
@@ -391,7 +393,7 @@ class Statsd
   end
 
   def socket
-    Thread.current[:statsd_socket] ||= UDPSocket.new addr_family
+    @socket || Thread.current[:statsd_socket] ||= UDPSocket.new(addr_family)
   end
 
   def addr_family

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -23,6 +23,17 @@ describe Statsd do
       statsd.host.must_equal '127.0.0.1'
       statsd.port.must_equal 8125
     end
+
+    it "uses the thread's socket by default" do
+      @statsd.socket.must_equal @socket
+    end
+
+    it "can use a single socket passed in" do
+      statsd_with_socket = Statsd.new('foo', 1234, :socket)
+      statsd_with_socket.socket.must_equal :socket
+      Thread.current[:statsd_socket] = FakeUDPSocket.new
+      statsd_with_socket.socket.must_equal :socket
+    end
   end
 
   describe "#host and #port" do


### PR DESCRIPTION
This leaves the current behavior unaffected, but provides an option of reusing a single socket for all the statsd, to avoid massive amounts of sockets being open/closed... or worse, opened and left...

A way to resolve https://github.com/reinh/statsd/issues/34 without creating a new socket for each stat.