### PR TITLE
Add the ability to pre-connect to the UDPSocket with `connect`

### DIFF
--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -371,6 +371,7 @@ describe Statsd do
     end
 
   end
+
 end
 
 describe Statsd do
@@ -406,6 +407,20 @@ describe Statsd do
       socket.bind(host, port)
 
       statsd = Statsd.new(host, port)
+      statsd.increment('foobar')
+      message = socket.recvfrom(16).first
+      message.must_equal 'foobar:1|c'
+    end
+
+    it "should be able to pre-connect" do
+      Thread.current[:statsd_socket] = nil
+      socket = UDPSocket.new
+      host, port = 'localhost', 12348
+      socket.bind(host, port)
+
+      statsd = Statsd.new(host, port)
+      statsd.connect
+      statsd.connected?.must_equal true
       statsd.increment('foobar')
       message = socket.recvfrom(16).first
       message.must_equal 'foobar:1|c'


### PR DESCRIPTION
In testing with a previous version of the statsd-ruby gem we noticed
that a lot of time was spent sending these UDP messages. Looking
at the Ruby API, I noticed that by calling `connect` on the socket
ahead of time, future sends on the socket were significantly faster.

This adds a `connect` method, that when called, no longer needs to send
host/port with every send.

In testing in production, it has reduced calls by greater than two orders of magnitude

```
       user     system      total        real
udp with connect  0.010000   0.000000   0.010000 (  0.074522)
udp without connect  0.120000   0.530000   0.650000 ( 13.096515)
statsd with connect  0.000000   0.090000   0.090000 (  0.103520)
statsd without connect  0.100000   0.620000   0.720000 ( 13.483539)
```