### PR TITLE
Timed explicit returns

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -350,8 +350,11 @@ class Statsd
   #   $statsd.time('account.activate') { @account.activate! }
   def time(stat, sample_rate=1)
     start = Time.now
-    result = yield
-    timing(stat, ((Time.now - start) * 1000).round, sample_rate)
+    begin
+      result = yield
+    ensure
+      timing(stat, ((Time.now - start) * 1000).round, sample_rate)
+    end
     result
   end
 

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -349,13 +349,14 @@ class Statsd
   # @example Report the time (in ms) taken to activate an account
   #   $statsd.time('account.activate') { @account.activate! }
   def time(stat, sample_rate=1)
+    exception_raised = false
     start = Time.now
-    begin
-      result = yield
-    ensure
-      timing(stat, ((Time.now - start) * 1000).round, sample_rate)
-    end
-    result
+    yield
+  rescue
+    exception_raised = true
+    raise
+  ensure
+    timing(stat, ((Time.now - start) * 1000).round, sample_rate) unless exception_raised
   end
 
   # Creates and yields a Batch that can be used to batch instrument reports into

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -142,6 +142,18 @@ describe Statsd do
       result.must_equal 'test'
     end
 
+    describe "when given a block with an explicit return" do
+      it "should format the message according to the statsd spec" do
+        lambda { @statsd.time('foobar') { return 'test' } }.call
+        @socket.recv.must_equal ['foobar:0|ms']
+      end
+
+      it "should return the result of the block" do
+        result = lambda { @statsd.time('foobar') { return 'test' } }.call
+        result.must_equal 'test'
+      end
+    end
+
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
 

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -154,6 +154,20 @@ describe Statsd do
       end
     end
 
+    describe "when given a block which throws an exception" do
+      it "should not send" do
+        begin
+          @statsd.time('foobar') { raise 'test' }
+        rescue
+        end
+        @socket.recv.must_equal nil
+      end
+
+      it "should not block the exception" do
+        proc { @statsd.time('foobar') { raise 'test' } }.must_raise RuntimeError
+      end
+    end
+
     describe "with a sample rate" do
       before { class << @statsd; def rand; 0; end; end } # ensure delivery
 


### PR DESCRIPTION
Allow explicit returns in timed blocks. Previously, metrics would not be sent if you explicitly returned from a method from inside a timed block. E.g.

```ruby
$statsd = Statsd.new '::1', 9125
def some_method
  $statsd.time('test') do
    sleep 1
    return "Explicitly returned string" 
  end
end
puts some_method
```