### PR TITLE
Add Ruby 2.0, 2.1, and 2.2. Remove 1.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: ruby
 rvm:
-- 1.8.7
 - 1.9.3
+- 2.0
+- 2.1
+- 2.2
 - jruby-19mode


### PR DESCRIPTION
Add some confidence that the tests are working against newer versions of
Ruby. Even Ruby 1.9.3 has reached end of life at this point. Removes
1.8.7 from the list as support for it is already broken (see #57).