### PR TITLE
Add TCP support

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -226,6 +226,9 @@ class Statsd
 
   # a postfix to append to all metrics
   attr_reader :postfix
+  
+  # the protocol to use when sending messages to the server (tcp or udp)
+  attr_reader :protocol
 
   class << self
     # Set to a standard logger instance to enable debug logging.
@@ -234,11 +237,12 @@ class Statsd
 
   # @param [String] host your statsd host
   # @param [Integer] port your statsd port
-  def initialize(host = '127.0.0.1', port = 8125)
+  def initialize(host = '127.0.0.1', port = 8125, protocol = :udp)
     self.host, self.port = host, port
     @prefix = nil
     @batch_size = 10
     @postfix = nil
+    @protocol = protocol || :udp
   end
 
   # @attribute [w] namespace
@@ -391,7 +395,12 @@ class Statsd
   end
 
   def socket
-    Thread.current[:statsd_socket] ||= UDPSocket.new addr_family
+    Thread.current[:statsd_socket] ||= build_socket
+  end
+
+  def build_socket
+    return UDPSocket.new(addr_family) if @protocol == :udp
+    TCPSocket.new(@host, @port)
   end
 
   def addr_family

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -412,3 +412,19 @@ describe Statsd do
     end
   end
 end if ENV['LIVE']
+
+describe Statsd do  
+  describe "with a real TCP socket" do
+    it "should actually send stuff over the socket" do
+      Thread.current[:statsd_socket] = nil
+      host, port = 'localhost', 12345
+      socket = TCPSocket.new host, port
+      socket.bind(host, port)
+
+      statsd = Statsd.new(host, port)
+      statsd.increment('foobar')
+      message = socket.recvfrom(16).first
+      message.must_equal 'foobar:1|c'
+    end
+  end
+end if ENV['LIVE_TCP']


### PR DESCRIPTION
Per issue #60 - Added an option to the Statsd class to allow a protocol to be specified (`:udp` or `:tcp`). 