### PR TITLE
make batch_size count bytes, not messages

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start
 require 'minitest/autorun'
 require 'statsd'
 require 'logger'
+require 'timeout'
 
 class FakeUDPSocket
   def initialize


### PR DESCRIPTION
otherwise it's impossible to properly fill a UDP packet, without
risking going over, due to varying lengths of messages