### PR TITLE
reconnect TCP after getting the TCP RST package

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -462,7 +462,11 @@ class Statsd
       # send(2) is atomic, however, in stream cases (TCP) the socket is left
       # in an inconsistent state if a partial message is written. If that case
       # occurs, the socket is closed down and we retry on a new socket.
-      n = socket.write(message)
+      begin
+        n = socket.write(message)
+      rescue SystemCallError
+        n = nil
+      end
 
       if n == message.length
         break


### PR DESCRIPTION
If the client gets a RST package from the server it has to reconnect. Otherwise no more stats will be sent