### PR TITLE
Fix incorrect time measurement by using monotonic time

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -2,6 +2,8 @@ require 'socket'
 require 'forwardable'
 require 'json'
 
+require 'statsd/monotonic_time'
+
 # = Statsd: A Statsd client (https://github.com/etsy/statsd)
 #
 # @example Set up a global Statsd client for a server on localhost:8125
@@ -408,10 +410,10 @@ class Statsd
   # @example Report the time (in ms) taken to activate an account
   #   $statsd.time('account.activate') { @account.activate! }
   def time(stat, sample_rate=1)
-    start = Time.now
+    start = MonotonicTime.time_in_ms
     result = yield
   ensure
-    timing(stat, ((Time.now - start) * 1000).round, sample_rate)
+    timing(stat, (MonotonicTime.time_in_ms - start).round, sample_rate)
     result
   end
 

--- a/lib/statsd/monotonic_time.rb
+++ b/lib/statsd/monotonic_time.rb
@@ -1,0 +1,35 @@
+class Statsd
+  # = MonotonicTime: a helper for getting monotonic time
+  #
+  # @example
+  #   MonotonicTime.time_in_ms #=> 287138801.144576
+
+  # MonotonicTime guarantees that the time is strictly linearly
+  # increasing (unlike realtime).
+  # @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/clock_getres.html
+  module MonotonicTime
+    class << self
+      # @return [Integer] current monotonic time in milliseconds
+      def time_in_ms
+        time_in_nanoseconds / (10.0 ** 6)
+      end
+
+      private
+
+      if defined?(Process::CLOCK_MONOTONIC)
+        def time_in_nanoseconds
+          Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+        end
+      elsif RUBY_ENGINE == 'jruby'
+        def time_in_nanoseconds
+          java.lang.System.nanoTime
+        end
+      else
+        def time_in_nanoseconds
+          t = Time.now
+          t.to_i * (10 ** 9) + t.nsec
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Statsd#time` uses the `Time` class to measure the difference between
elapsed time. This is incorrect because `Time.now` uses realtime,
which is meant to be used for system clock.

`clock_gettime` from `time.h` supports *monotonic time*. Let me quote
the man page of `clock_gettime` man to demonstrate the difference
between them:

> CLOCK_REALTIME
> the system's real time (i.e. wall time) clock, expressed as the
> amount of time since the Epoch.

> CLOCK_MONOTONIC
> clock that increments monotonically, tracking the time since an
> arbitrary point, and will continue to increment while the system is
> asleep.

Since we measure elapsed time, we should be using monotonic time,
since it more accurate and meant to be used for that reason.