### PR TITLE
Adds support for sending tags in the Datadog StatsD format

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -27,6 +27,10 @@ Bundler:
   statsd = Statsd.new('localhost').tap{|sd| sd.namespace = 'account'}
   statsd.increment 'activate'
 
+  # Include tags with metrics
+  statsd.global_tags = ['system:api']
+  statsd.increment 'activate', ['result:success']
+
 = Testing
 
 Run the specs with <tt>rake spec</tt>

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -95,6 +95,21 @@ describe Statsd do
         @socket.recv.must_equal ['foobar:1|c|@0.5']
       end
     end
+
+    describe "with tags" do
+      it "should format the message according to the statsd spec" do
+        @statsd.increment('foobar', ['result:success', 'type:first'])
+        @socket.recv.must_equal ['foobar:1|c|#result:success,type:first']
+      end
+    end
+
+    describe "with a sample rate and tags" do
+      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      it "should format the message according to the statsd spec" do
+        @statsd.increment('foobar', 0.5, ['result:success', 'type:first'])
+        @socket.recv.must_equal ['foobar:1|c|@0.5|#result:success,type:first']
+      end
+    end
   end
 
   describe "#decrement" do
@@ -108,6 +123,21 @@ describe Statsd do
       it "should format the message according to the statsd spec" do
         @statsd.decrement('foobar', 0.5)
         @socket.recv.must_equal ['foobar:-1|c|@0.5']
+      end
+    end
+
+    describe "with tags" do
+      it "should format the message according to the statsd spec" do
+        @statsd.decrement('foobar', ['result:success', 'type:first'])
+        @socket.recv.must_equal ['foobar:-1|c|#result:success,type:first']
+      end
+    end
+
+    describe "with a sample rate and tags" do
+      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      it "should format the message according to the statsd spec" do
+        @statsd.decrement('foobar', 0.5, ['result:success', 'type:first'])
+        @socket.recv.must_equal ['foobar:-1|c|@0.5|#result:success,type:first']
       end
     end
   end
@@ -127,6 +157,21 @@ describe Statsd do
         @socket.recv.must_equal ['begrutten-suffusion:536|g|@0.1']
       end
     end
+
+    describe "with tags" do
+      it "should format the message according to the statsd spec" do
+        @statsd.gauge('begrutten-suffusion', 536, ['result:success', 'type:first'])
+        @socket.recv.must_equal ['begrutten-suffusion:536|g|#result:success,type:first']
+      end
+    end
+
+    describe "with a sample rate and tags" do
+      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      it "should format the message according to the statsd spec" do
+        @statsd.gauge('begrutten-suffusion', 536, 0.1, ['result:success', 'type:first'])
+        @socket.recv.must_equal ['begrutten-suffusion:536|g|@0.1|#result:success,type:first']
+      end
+    end
   end
 
   describe "#timing" do
@@ -142,6 +187,21 @@ describe Statsd do
         @socket.recv.must_equal ['foobar:500|ms|@0.5']
       end
     end
+
+    describe "with tags" do
+      it "should format the message according to the statsd spec" do
+        @statsd.timing('foobar', 500, ['result:success', 'type:first'])
+        @socket.recv.must_equal ['foobar:500|ms|#result:success,type:first']
+      end
+    end
+
+    describe "with a sample rate and tags" do
+      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      it "should format the message according to the statsd spec" do
+        @statsd.timing('foobar', 500, 0.5, ['result:success', 'type:first'])
+        @socket.recv.must_equal ['foobar:500|ms|@0.5|#result:success,type:first']
+      end
+    end
   end
 
   describe "#set" do
@@ -155,6 +215,21 @@ describe Statsd do
       it "should format the message according to the statsd spec" do
         @statsd.set('foobar', 500, 0.5)
         @socket.recv.must_equal ['foobar:500|s|@0.5']
+      end
+    end
+
+    describe "with tags" do
+      it "should format the message according to the statsd spec" do
+        @statsd.set('foobar', 500, ['result:success', 'type:first'])
+        @socket.recv.must_equal ['foobar:500|s|#result:success,type:first']
+      end
+    end
+
+    describe "with a sample rate and tags" do
+      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      it "should format the message according to the statsd spec" do
+        @statsd.set('foobar', 500, 0.5, ['result:success', 'type:first'])
+        @socket.recv.must_equal ['foobar:500|s|@0.5|#result:success,type:first']
       end
     end
   end
@@ -188,6 +263,21 @@ describe Statsd do
       it "should format the message according to the statsd spec" do
         @statsd.time('foobar', 0.5) { 'test' }
         @socket.recv.must_equal ['foobar:0|ms|@0.5']
+      end
+    end
+
+    describe "with tags" do
+      it "should format the message according to the statsd spec" do
+        @statsd.time('foobar', ['result:success', 'type:first']) { 'test' }
+        @socket.recv.must_equal ['foobar:0|ms|#result:success,type:first']
+      end
+    end
+
+    describe "with a sample rate and tags" do
+      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      it "should format the message according to the statsd spec" do
+        @statsd.time('foobar', 0.5, ['result:success', 'type:first']) { 'test' }
+        @socket.recv.must_equal ['foobar:0|ms|@0.5|#result:success,type:first']
       end
     end
   end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -427,6 +427,20 @@ describe Statsd do
     end
   end
 
+  describe "with global tags" do
+    before { @statsd.global_tags = ['service:api','host:sirius'] }
+
+    it "should add global tags to measurement" do
+      @statsd.increment('foobar')
+      @socket.recv.must_equal ['foobar:1|c|#service:api,host:sirius']
+    end
+
+    it "should combine tags with global tags" do
+      @statsd.decrement('foobar', ['result:success'])
+      @socket.recv.must_equal ['foobar:-1|c|#result:success,service:api,host:sirius']
+    end
+  end
+
   describe "handling socket errors" do
     before do
       require 'stringio'


### PR DESCRIPTION
Adds optional support for sending global tags and metric-specific tags. The tag format is compatible with Datadog StatsD and Telegraf.