### PR TITLE
Fix TCP support

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -96,7 +96,7 @@ class Statsd
       # one, so the post-queue check will always catch it
       if (@batch_byte_size && @backlog_bytesize + message.bytesize + 1 > @batch_byte_size) ||
           (@flush_interval && last_flush_seconds_ago >= @flush_interval)
-        flush 
+        flush
       end
       @backlog << message
       @backlog_bytesize += message.bytesize
@@ -476,8 +476,8 @@ class Statsd
       # send(2) is atomic, however, in stream cases (TCP) the socket is left
       # in an inconsistent state if a partial message is written. If that case
       # occurs, the socket is closed down and we retry on a new socket.
+      message = @protocol == :tcp ? message + "\n" : message
       n = socket.write(message)
-
       if n == message.length
         break
       end

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -70,12 +70,12 @@ describe Statsd do
     end
   end
 
-  describe "#delimiter" do 
+  describe "#delimiter" do
     it "should set delimiter" do
       @statsd.delimiter = "-"
       @statsd.delimiter.must_equal "-"
     end
-    
+
     it "should set default to period if not given a value" do
       @statsd.delimiter = nil
       @statsd.delimiter.must_equal "."
@@ -559,7 +559,7 @@ describe Statsd do
         end
 
         message = socket.recvfrom(16).first
-        message.must_equal 'foobar:1|c'
+        message.must_equal "foobar:1|c\n"
       ensure
         socket.close if socket
         server.close
@@ -583,7 +583,7 @@ describe Statsd do
         end
 
         message = socket.recvfrom(16).first
-        message.must_equal 'foobar:1|c'
+        message.must_equal "foobar:1|c\n"
       ensure
         socket.close if socket
         server.close


### PR DESCRIPTION
Fixes #76.

As [described by Statsd](https://github.com/statsd/statsd/blob/3a3ced99de00855dfc0a45386f466ad5a8d8a549/docs/server.md), "each metric must be terminated by the \n character when received over TCP". I've tested this fix against Statsd and found that it works.