### PR TITLE
Add Ruby 2.7, 3.0, and 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
           - 2.4
           - 2.5
           - 2.6
-          # TODO: - 2.7
+          - 2.7
+          - '3.0'
+          - 3.1
           # TODO: jruby, rbx
 
     runs-on: ${{ matrix.os }}-latest
@@ -22,10 +24,9 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        architecture: x64
 
     - name: Build and test with Rake
       run: |


### PR DESCRIPTION
This updates the CI config to use the current setup-ruby job and adds Ruby 2.7, 3.0, and 3.1 to CI.