### PR TITLE
Adds Ruby 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,13 @@ jobs:
           - 2.7
           - '3.0'
           - 3.1
+          - 3.2
           # TODO: jruby, rbx
 
     runs-on: ${{ matrix.os }}-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler: 2.3.26
 
     - name: Build and test with Rake
       run: |
-        gem install bundler
         bundle install
         bundle exec rake


### PR DESCRIPTION
Also updates the checkout action version.

The bundler version needs to be explicitly set to support Rubies that are 2.5 and earlier.

This runs green on my fork.