### PR TITLE
Freeze string literals

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'socket'
 require 'forwardable'
 require 'json'


### PR DESCRIPTION
Delivering stats allocates a good number of string literals. When used intensively, freezing strings can save a lot of allocations.
